### PR TITLE
Scanco Units Conversion notebook v3

### DIFF
--- a/ITKIOScanco_UnitConversion.ipynb
+++ b/ITKIOScanco_UnitConversion.ipynb
@@ -18,15 +18,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
+    "# Install non-default packages\n",
+    "import sys\n",
+    "!{sys.executable} -m pip install itk pooch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import required packages\n",
+    "from pathlib import Path\n",
     "import re\n",
     "import itk\n",
-    "import glob\n",
-    "import argparse"
+    "import pooch\n",
+    "import glob"
    ]
   },
   {
@@ -41,23 +53,28 @@
     "\n",
     "all_AIM_filenames = glob.glob(\"*.AIM\")\n",
     "all_ISQ_filenames = glob.glob(\"*.ISQ\")\n",
-    "all_filenames = all_AIM_filenames + all_ISQ_filenames\n",
-    "\n",
-    "del all_AIM_filenames, all_ISQ_filenames\n"
+    "all_filenames = all_AIM_filenames + all_ISQ_filenames\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
-    "filename = 'C0005757_SCAP.AIM'\n",
-    "image = itk.imread(filename)\n",
+    "# This cell originally operated on the image C0005757_SCAP.AIM, though for the purposes of employing pooch, a sample file stored online at the provided URL is now used.\n",
+    "# This section will need to be modified to handle general implementation.\n",
+    "\n",
+    "# filename = 'C0005757_SCAP.AIM'\n",
+    "filename = 'C0004255.ISQ'\n",
+    "file_url = 'https://data.kitware.com/api/v1/file/591e56178d777f16d01e0d20/download'\n",
+    "file_sha256 = 'c2a3750c75826cb077d92093d43976cc0350198b55edecd681265eebabfb438b'\n",
+    "file_path = pooch.retrieve(file_url, file_sha256, fname=filename, progressbar=False)\n",
+    "image = itk.imread(file_path)\n",
     "metadata = dict(image)\n",
-    "HUpixels = itk.array_view_from_image(image)\n",
-    "del image\n",
-    "# HUpixels = np.array(HUpixels)                     # Array arithmetic below seems to work without this line, but certain operations were not tested as they require too much memory"
+    "HU_pixels = itk.array_view_from_image(image)\n",
+    "# del image\n",
+    "# HU_pixels = np.array(HU_pixels)                     # Array arithmetic below seems to work without this line, but certain operations were not tested as they require too much memory"
    ]
   },
   {
@@ -68,8 +85,14 @@
    "source": [
     "# As discussed below, some required constants are missing from metadata. Compare the output of this cell with the file header at:\n",
     "# https://docs.google.com/document/d/1L2GCnHa4jmK87p0pGI9MNN10MWRMwrk2WqPbPeklP_I/edit\n",
+    "# This section does, however, collect some metadata and write it to a .txt file.\n",
     "\n",
-    "print(metadata)"
+    "print(metadata)\n",
+    "metadata_str = str(metadata)\n",
+    "\n",
+    "metadata_outname = Path(filename).stem + \"_metadata.txt\"\n",
+    "with open(metadata_outname, \"w\") as file:\n",
+    "    file.write(metadata_str)"
    ]
   },
   {
@@ -87,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,101 +127,98 @@
     "# necessary constants. For an example of a full file header with highlighted variables of interest, see the google doc \n",
     "# \"SCANCO micro-CT Units Conversion\" at: https://docs.google.com/document/d/1L2GCnHa4jmK87p0pGI9MNN10MWRMwrk2WqPbPeklP_I/edit\n",
     "\n",
-    "mu_threshLow = 0.250\n",
-    "mu_threshHigh = 1.0\n",
+    "# Thresholds must be entered by the user, they are not contained in the file header\n",
+    "mu_threshold_low = 0.250\n",
+    "mu_threshold_high = 1.0\n",
     "\n",
-    "scancoMU = float(re.search('Global Scaled by factor=(.*?),', header).group(1))\n",
-    "# scancoMU = metadata['MuScaling']\n",
-    "maxVal = float(re.search('Global Maximum data value=(.*?),', header).group(1))\n",
-    "# maxVal = metadata['**********']\n",
-    "densitySlope = float(re.search('slope=(.*?),', header).group(1))\n",
-    "# densitySlope = metadata['**********']\n",
-    "densityIntercept = float(re.search('intercept=(.*?),', header).group(1))\n",
-    "# densityIntercept = metadata['**********']\n",
+    "scanco_mu = float(re.search('Global Scaled by factor=(.*?),', header).group(1))\n",
+    "# scanco_mu = metadata['MuScaling']\n",
+    "max_val = float(re.search('Global Maximum data value=(.*?),', header).group(1))\n",
+    "# max_val = metadata['**********']\n",
+    "density_slope = float(re.search('slope=(.*?),', header).group(1))\n",
+    "# density_slope = metadata['**********']\n",
+    "density_intercept = float(re.search('intercept=(.*?),', header).group(1))\n",
+    "# density_intercept = metadata['**********']\n",
     "water_mu = float(re.search('water=(.*?),', header).group(1))\n",
     "# water_mu = metadata['MuWater']\n",
     "\n",
     "# del header                  # when the code base is modified such that metadata gives all relevant constants, this line and others that reference \"header\" can be deleted\n",
     "# del metadata\n",
     "\n",
-    "muLow = mu_threshLow * maxVal\n",
-    "mu_pixelLow = muLow/scancoMU\n",
-    "muHigh = mu_threshHigh * maxVal\n",
-    "mu_pixelHigh = muHigh/scancoMU\n",
-    "HU_pixelLow = (-1000) + mu_pixelLow * (1000/water_mu)\n",
-    "HU_pixelHigh = (-1000) + mu_pixelHigh * (1000/water_mu)\n",
-    "HUvalues = [HU_pixelLow, HU_pixelHigh]"
+    "mu_low = mu_threshold_low * max_val\n",
+    "mu_pixel_low = mu_low/scanco_mu\n",
+    "mu_high = mu_threshold_high * max_val\n",
+    "mu_pixel_high = mu_high/scanco_mu\n",
+    "HU_pixel_low = (-1000) + mu_pixel_low * (1000/water_mu)\n",
+    "HU_pixel_high = (-1000) + mu_pixel_high * (1000/water_mu)\n",
+    "HU_values = [HU_pixel_low, HU_pixel_high]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
-    "PixelType = itk.SS\n",
-    "Dimension = 3\n",
+    "# Create a binarized version of the input image by applying low and high thresholds. Threshold values are accepted as int type variables, so some rounding is necessary.\n",
+    "lower_threshold = int(round(HU_values[0]))\n",
+    "upper_threshold = int(round(HU_values[1]))\n",
+    "inside_value = 1\n",
+    "outside_value = 0\n",
     "\n",
-    "ImageType = itk.Image[PixelType, Dimension]\n",
+    "BW_image = itk.binary_threshold_image_filter(image,lower_threshold=lower_threshold,upper_threshold=upper_threshold,inside_value=inside_value,outside_value=outside_value)\n",
     "\n",
-    "reader = itk.ImageFileReader[ImageType].New()\n",
-    "reader.SetFileName(filename)\n",
+    "BW_outname = Path(filename).stem + \"_BWmask.nrrd\"\n",
     "\n",
-    "thresholdFilter = itk.BinaryThresholdImageFilter[ImageType, ImageType].New()\n",
-    "thresholdFilter.SetInput(reader.GetOutput())\n",
+    "itk.imwrite(BW_image, BW_outname)\n",
     "\n",
-    "thresholdFilter.SetLowerThreshold(int(HUvalues[0]))\n",
-    "thresholdFilter.SetUpperThreshold(int(HUvalues[1]))\n",
-    "thresholdFilter.SetOutsideValue(int(0))\n",
-    "thresholdFilter.SetInsideValue(int(1))\n",
-    "\n",
-    "BWoutname = filename[0:-4] + '_BWmask.nrrd'\n",
-    "\n",
-    "writer = itk.ImageFileWriter[ImageType].New()\n",
-    "writer.SetFileName(BWoutname)\n",
-    "writer.SetInput(thresholdFilter.GetOutput())\n",
-    "\n",
-    "writer.Update()"
+    "# The following can be enabled to free up memory\n",
+    "# del image\n",
+    "# del BW_image"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create unit-converted outputs. MUpixels is not desired as an output due to representing non-standard units. However, creation of MUpixels\n",
+    "# Create unit-converted outputs. MUpixels is not generally desired as an output due to representing non-standard units. However, creation of MUpixels\n",
     "# can be skipped, as RHOpixels can be created by combining the functions needed to convert HU to MU and MU to RHO.\n",
     "\n",
     "# MUpixels = (HUpixels+1000)/(1000/water_mu)\n",
     "# RHOpixels = (MUpixels*densitySlope) + densityIntercept\n",
-    "RHOpixels = ((((HUpixels+1000)/(1000/water_mu))*densitySlope) + densityIntercept)/1000  # Dividing by 1000 at the end changes units from mg/cc to g/cc, which is more commonly published\n"
+    "RHO_pixels = ((((HU_pixels+1000)/(1000/water_mu))*density_slope) + density_intercept)/1000  # Dividing by 1000 at the end changes units from mg/cc to g/cc, which is more commonly published\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Create .nrrd file output with units of density (mg/cc or g/cc)\n",
     "\n",
-    "RHOout = itk.image_view_from_array(RHOpixels)\n",
-    "RHOoutname = filename[0:-4] + '_RHO.nrrd'\n",
-    "itk.imwrite(RHOout, RHOoutname)"
+    "RHO_out = itk.image_view_from_array(RHO_pixels)\n",
+    "for k, v in metadata.items():\n",
+    "    RHO_out[k] = v\n",
+    "RHO_outname = Path(filename).stem + \"_RHO.nrrd\"\n",
+    "itk.imwrite(RHO_out, RHO_outname)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Create .nrrd file output with Hounsfield Units (equivalent to loading the file in 3D Slicer)\n",
     "\n",
-    "HUout = itk.image_view_from_array(HUpixels)\n",
-    "HUoutname = filename[0:-4] + '_HU.nrrd'\n",
-    "itk.imwrite(HUout, HUoutname)"
+    "HU_out = itk.image_view_from_array(HU_pixels)\n",
+    "for k, v in metadata.items():\n",
+    "    HU_out[k] = v\n",
+    "HU_outname = Path(filename).stem + \"_HU.nrrd\"\n",
+    "itk.imwrite(HU_out, HU_outname)"
    ]
   }
  ],


### PR DESCRIPTION
This is the 3rd version of a Python notebook composed to read in SCANCO .AIM or .ISQ images and convert the native units to Hounsfield Units and units of density (g/cc), with new images saved for each converted unit. A binary image mask is also created, and the original file metadata is written to a .txt file.